### PR TITLE
Added nodemon to devDependencies for users who don't have it globally

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -43,6 +43,7 @@
     "create-react-app": "^1.3.3",
     "eslint": "^4.3.0",
     "jest": "^20.0.4",
+    "nodemon": "^1.12.1",
     "react-script": "^2.0.5"
   },
   "jest": {


### PR DESCRIPTION
I didn't have nodemon already installed globally, so my `npm start` script wouldn't work. I added it to my devDependencies in package.json, and that fixed it.